### PR TITLE
Add CLM variable constants (clm_varcon.py) and files supporting translation

### DIFF
--- a/.github/prompts/translate.prompt.md
+++ b/.github/prompts/translate.prompt.md
@@ -1,0 +1,24 @@
+---
+mode: agent
+---
+
+Your primary responsibilities:
+1. Convert Fortran code to idiomatic JAX/Python
+2. Apply JAX best practices (pure functions, immutable state, JIT-compatible)
+3. Preserve exact scientific formulas and physics
+4. Follow established patterns from the jax-ctsm codebase
+5. Generate comprehensive type hints and docstrings
+6. Convert loops to vectorized operations
+7. Keep all the names exactly the same as in the Fortran code and keep all the dependencies as well
+8. Map Fortran spatial hierarchy to JAX index-based arrays
+
+Core JAX Principles to Follow:
+- Pure functions (no side effects, no mutations)
+- Immutable data structures (NamedTuples, not classes with __init__)
+- JIT-compatible (no Python if with JAX arrays, use jnp.where instead)
+- Vectorized operations (no Python loops, use jnp operations or vmap)
+- Type hints for all functions
+- Google-style docstrings with Args, Returns, and examples
+
+Using static analysis output of the module dependencies and metadata, and the corresponding fortran code lines, generate a JAX/Python translation of the code following the best coding practices. 
+Rename the py. file with the same name as the fortran file.

--- a/src/jax_ctsm/core/clm_varcon.py
+++ b/src/jax_ctsm/core/clm_varcon.py
@@ -1,0 +1,65 @@
+"""
+JAX translation of CLM Fortran module clm_varcon.
+
+This module provides model constants, preserving the shr_kind_mod context by mapping r8 to jnp.float64.
+All names are kept exactly as in the Fortran code. All constants are JIT-compatible and immutable.
+"""
+
+from typing import Final
+import jax.numpy as jnp
+
+# Fortran kind mapping: use shr_kind_mod, only : r8 => shr_kind_r8
+# In JAX/Python, r8 is mapped to jnp.float64 for full precision.
+r8: Final = jnp.float64
+
+# Mathematical constants used in CLM
+rpi: Final = r8(3.141592654)  # pi
+
+# Physical constants used in CLM
+tfrz: Final = r8(273.15)      # Freezing point of water (K)
+sb: Final = r8(5.67e-08)      # Stefan-Boltzmann constant (W/m2/K4)
+grav: Final = r8(9.80665)      # Gravitational acceleration (m/s2)
+vkc: Final = r8(0.4)           # von Karman constant
+denh2o: Final = r8(1000.0)     # Density of liquid water (kg/m3)
+denice: Final = r8(917.0)      # Density of ice (kg/m3)
+tkwat: Final = r8(0.57)        # Thermal conductivity of water (W/m/K)
+tkice: Final = r8(2.29)        # Thermal conductivity of ice (W/m/K)
+tkair: Final = r8(0.023)       # Thermal conductivity of air (W/m/K)
+hfus: Final = r8(0.3337e6)     # Latent heat of fusion for water at 0 C (J/kg)
+hvap: Final = r8(2.5010e6)     # Latent heat of evaporation (J/kg)
+hsub: Final = r8(2.8347e6)     # Latent heat of sublimation (J/kg)
+cpice: Final = r8(2.11727e3)   # Specific heat of ice (J/kg/K)
+cpliq: Final = r8(4.188e3)     # Specific heat of water (J/kg/K)
+
+# Constants used in CLM for bedrock
+thk_bedrock: Final = r8(3.0)        # Thermal conductivity of saturated granitic rock (W/m/K)
+csol_bedrock: Final = r8(2.0e6)      # Vol. heat capacity of granite/sandstone (J/m3/K)
+zmin_bedrock: Final = r8(0.4)        # Minimum depth to bedrock (soil depth) [m]
+
+# Special value flags used in CLM
+spval: Final = r8(1.0e36)           # Special value for real data
+ispval: Final = -9999               # Special value for integer data
+
+__all__ = [
+    "r8",
+    "rpi",
+    "tfrz",
+    "sb",
+    "grav",
+    "vkc",
+    "denh2o",
+    "denice",
+    "tkwat",
+    "tkice",
+    "tkair",
+    "hfus",
+    "hvap",
+    "hsub",
+    "cpice",
+    "cpliq",
+    "thk_bedrock",
+    "csol_bedrock",
+    "zmin_bedrock",
+    "spval",
+    "ispval",
+]

--- a/src/temp_input.txt
+++ b/src/temp_input.txt
@@ -1,0 +1,90 @@
+module clm_varcon
+
+  !-----------------------------------------------------------------------
+  ! !DESCRIPTION:
+  ! Module containing various model constants
+  !
+  ! !USES:
+  use shr_kind_mod, only : r8 => shr_kind_r8
+  !
+  ! !PUBLIC TYPES:
+  implicit none
+
+  ! Mathematical constants used in CLM
+
+  real(r8) :: rpi = 3.141592654_r8          ! pi
+
+  ! Physical constants used in CLM
+
+  real(r8), parameter :: tfrz = 273.15_r8   ! Freezing point of water (K)
+  real(r8) :: sb = 5.67e-08_r8              ! Stefan-Boltzmann constant (W/m2/K4)
+  real(r8) :: grav = 9.80665_r8             ! Gravitational acceleration (m/s2)
+  real(r8) :: vkc = 0.4_r8                  ! von Karman constant
+  real(r8) :: denh2o = 1000._r8             ! Density of liquid water (kg/m3)
+  real(r8) :: denice = 917._r8              ! Density of ice (kg/m3)
+  real(r8) :: tkwat = 0.57_r8               ! Thermal conductivity of water (W/m/K)
+  real(r8) :: tkice = 2.29_r8               ! Thermal conductivity of ice (W/m/K)
+  real(r8) :: tkair = 0.023_r8              ! Thermal conductivity of air (W/m/K)
+  real(r8) :: hfus = 0.3337e6_r8            ! Latent heat of fusion for water at 0 C (J/kg)
+  real(r8) :: hvap = 2.5010e6_r8            ! Latent heat of evaporation (J/kg)
+  real(r8) :: hsub = 2.8347e6_r8            ! Latent heat of sublimation (J/kg)
+  real(r8) :: cpice = 2.11727e3_r8          ! Specific heat of ice (J/kg/K)
+  real(r8) :: cpliq = 4.188e3_r8            ! Specific heat of water (J/kg/K)
+
+  ! Constants used in CLM for bedrock
+
+  real(r8) :: thk_bedrock = 3.0_r8          ! Thermal conductivity of saturated granitic rock (W/m/K)
+  real(r8) :: csol_bedrock = 2.0e6_r8       ! Vol. heat capacity of granite/sandstone (J/m3/K)
+  real(r8) :: zmin_bedrock = 0.4_r8         ! Minimum depth to bedrock (soil depth) [m]
+
+  ! Special value flags used in CLM
+
+  real(r8), parameter ::  spval = 1.e36_r8  ! Special value for real data
+  integer , parameter :: ispval = -9999     ! Special value for integer data
+
+end module clm_varcon
+
+
+"clm_varcon": {
+        "name": "clm_varcon",
+        "file_path": "/burg-archive/home/al4385/CLM-ml_v1/clm_src_main/clm_varcon.F90",
+        "uses": [
+          {
+            "module": "shr_kind_mod",
+            "only": [
+              "r8 => shr_kind_r8"
+            ]
+          }
+        ],
+        "subroutines": [],
+        "functions": [],
+        "types": [],
+        "variables": [],
+        "interfaces": [],
+        "line_count": 45,
+        "entities": []
+      },
+
+
+
+       {
+      "id": "clm_varcon_module_072",
+      "unit_type": "module",
+      "entity_name": "clm_varcon",
+      "entity_type": "module",
+      "module_name": "clm_varcon",
+      "file_path": "/burg-archive/home/al4385/CLM-ml_v1/clm_src_main/clm_varcon.F90",
+      "line_start": 1,
+      "line_end": 45,
+      "line_count": 45,
+      "parent_id": null,
+      "child_ids": [],
+      "depends_on": [],
+      "used_by": [],
+      "has_interfaces": false,
+      "has_types": false,
+      "complexity_score": 4.5,
+      "priority": 1,
+      "estimated_effort": "low",
+      "notes": []
+    },


### PR DESCRIPTION
This pull request adds 3 new files: 
* `src/jax_ctsm/core/clm_varcon.py`: The main file containing the CLM variable constants.
* `src/temp_input.txt`: A temporary input file for testing.
* `.github/prompts/translate.prompt.md`: The translation prompt file.